### PR TITLE
fix: increase cache time to 15 minutes for querying supported tokens …

### DIFF
--- a/routes/v1/chains/:chainId/tokens/index.mjs
+++ b/routes/v1/chains/:chainId/tokens/index.mjs
@@ -1,7 +1,7 @@
 import ms from "ms";
 
 export const makeTokensSupportedCacheKey = (chainId) => `tokens.supported.${chainId}`;
-export const TokensSupportedCacheTime = ms("10 minutes");
+export const TokensSupportedCacheTime = ms("15 minutes");
 
 export const makeTokensMetadataCacheKey = (chainId) => `tokens.metadata.${chainId}`;
 export const TokensMetadataCacheTime = ms("10 minutes");


### PR DESCRIPTION
…from zapper.

We're getting many `429` rate limit responses from zapper. Try to increase the cache duration and see if that improves the situation.