### PR TITLE
fix: update mainnet subgraph endpoint

### DIFF
--- a/plugins/sdk.mjs
+++ b/plugins/sdk.mjs
@@ -39,8 +39,7 @@ const makeSdks = () => {
       disableAllowlist: true,
       cache: { useCache: false },
       subgraph: {
-        mainnetSubgraphId: process.env.MAINNET_SUBGRAPH_ID,
-        subgraphKey: process.env.SUBGRAPH_API_KEY,
+        mainnetSubgraphEndpoint: process.env.MAINNET_SUBGRAPH_ENDPOINT,
       },
     });
     sdks[chain] = sdk;


### PR DESCRIPTION
new sdk version no longer takes an ID + key, now it takes the whole endpoint 